### PR TITLE
Move embedded Google Group to link

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,23 +95,9 @@
 	<li><a href="https://github.com/krkrz/kag3_ham">鱧入りKAG3 for 吉里吉里Z</a></li>
 </ul>
 <br />
-<div class="title_bar"><a name="google_group_qa">掲示板 (Googleグループ)</a></div>
-<iframe id="forum_embed"
-  src="javascript:void(0)"
-  scrolling="no"
-  frameborder="0"
-  width="900"
-  height="700">
-</iframe>
-<script type="text/javascript">
-  document.getElementById('forum_embed').src =
-     'https://groups.google.com/forum/embed/?place=forum/krkrzqa'
-     + '&showsearch=true&showpopout=true&showtabs=false'
-     + '&parenturl=' + encodeURIComponent(window.location.href);
-</script>
-<br />
 <div class="title_bar"><a name="site">その他サイト</a></div>
 <ul>
+	<li><a href="https://groups.google.com/forum/?hl=ja#!forum/krkrzqa">吉里吉里Z 掲示板 (Googleグループ)</a></li>
 	<li><a href="https://groups.google.com/forum/?hl=ja#!forum/krkrz">吉里吉里Z 開発情報(Googleグループ)</a></li>
 	<li><a href="https://github.com/krkrz/krkrz/issues">不具合報告・機能追加要望</a></li>
 <!--	<li><a href="https://github.com/krkrz/krkrz_question/issues">質問</a></li> -->


### PR DESCRIPTION
Google is turning off embedding soon, as seen in this image:

![image](https://user-images.githubusercontent.com/1689374/103118742-dc68d180-4635-11eb-8701-29d520fd1967.png)

Turn it to a link.